### PR TITLE
Remember player name for submissions

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -20,6 +20,7 @@ class GamesController < ApplicationController
   end
 
   def show
+    cookies.delete(:player_id)
   end
 
   def edit
@@ -50,6 +51,7 @@ class GamesController < ApplicationController
   def destroy
     @game.destroy
 
+    cookies.delete(:player_id)
     notice = "Game at #{@game.date} was successfully deleted."
     redirect_to games_url, notice: notice
   end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -9,12 +9,14 @@ class PlayersController < ApplicationController
 
   def new
     @player = Player.new
+    cookies.delete(:player_id)
   end
 
   def create
-    @player = @game.players.new(player_params.except(:game_code))
+    player = @game.players.new(player_params.except(:game_code))
 
-    if @player.save
+    if player.save
+      cookies[:player_id] = { value: player.id, expires: 1.day.from_now }
       redirect_to game_players_url(@game)
     else
       render :new

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -4,7 +4,7 @@ class SubmissionsController < ApplicationController
   before_action :set_game, only: %i[index new create show edit update destroy]
   before_action :set_round, only: %i[index new create show edit update destroy]
   before_action :set_submission, only: %i[show destroy]
-
+  before_action :set_player, only: %i[new create]
 
   def new
     @submission = @round.submissions.new
@@ -14,11 +14,11 @@ class SubmissionsController < ApplicationController
   end
 
   def create
-    @submission = @round.submissions.new(submission_params)
+    submission = @round.submissions.new(submission_params)
+    submission.nominator_id = @player.id
 
-    if @submission.save
-      redirect_to game_round_submission_url(@game, @round, @submission)
-      # redirect_to game_round_url(@game, @round)
+    if submission.save
+      redirect_to game_round_submission_url(@game, @round, submission)
     else
       render :new
     end
@@ -36,6 +36,10 @@ class SubmissionsController < ApplicationController
 
   def set_game
     @game = Game.find(params[:game_id])
+  end
+
+  def set_player
+    @player = Player.find_by(id: cookies[:player_id].to_i)
   end
 
   def submission_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,7 +7,7 @@ module ApplicationHelper
     if content_for?(:title)
       content_for(:title)
     else
-      'Voting Game'
+      'BlameGame'
     end
   end
 

--- a/app/helpers/players_helper.rb
+++ b/app/helpers/players_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module PlayersHelper
+  def players_minus_nominator(game, nominator)
+    game.players.where.not(id: nominator.id)
+  end
+end

--- a/app/views/games/index.html.erb
+++ b/app/views/games/index.html.erb
@@ -53,7 +53,10 @@
     <tr>
       <td><%= game.date %></td>
       <td><%= link_to game.code, game %></td>
-      <td><%= display_players(game) %></td>
+      <td>
+        Winner: <%= display_winner(game) %> <br>
+        <%= display_players(game) %>
+      </td>
       <td><%= game.players_ready? %></td>
       <td><%= link_to 'Edit', edit_game_path(game) %></td>
       <td><%= link_to 'Delete', game, method: :delete, data: {confirm: 'are you sure?'} %></td>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -11,7 +11,6 @@
   </div>
 </div>
 
-
 <h3>a recap of winners by round:</h3>
 <% @game.rounds.each do |round| %>
   <h4><%= round.number %>. <%= round.question.text %></h4>
@@ -23,11 +22,3 @@
     <% end %>
   </p>
 <% end %>
-
-
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    localStorage.removeItem('game_id');
-    localStorage.removeItem('player_name');
-  })
-</script>

--- a/app/views/players/new.html.erb
+++ b/app/views/players/new.html.erb
@@ -3,12 +3,12 @@
 
   <div class='field'>
     <%= form.label :game_code %>
-    <%= form.text_field :game_code, autofocus: true, placeholder: 'Ex: HMJY', id: 'game-code-field', class: 'form-control' %>
+    <%= form.text_field :game_code, autofocus: true, placeholder: 'Ex: HMJY', class: 'form-control' %>
   </div>
 
   <div class='field'>
     <%= form.label :name %>
-    <%= form.text_field :name, placeholder: 'Enter your name', onblur: 'storePlayerName()', id: 'name-field', class: 'form-control' %>
+    <%= form.text_field :name, placeholder: 'Enter your name', class: 'form-control' %>
   </div>
 
   <div class="mt-5 mb-5">
@@ -17,11 +17,11 @@
 <% end %>
 
 <script>
-  function storePlayerName(){
-    let nameField = document.getElementById('name-field')
-    let gameCodeField = document.getElementById('game-code-field')
-    console.log(nameField.value);
-    localStorage.setItem('player_name', nameField.value);
-    localStorage.setItem('game_id', gameCodeField.value);
-  }
+  document.addEventListener('DOMContentLoaded', function () {
+    let cookieNotice = localStorage.getItem('cookie_notice')
+    if (cookieNotice != 'true') {
+      alert("Hi there! This site uses a cookie to remember your name. We delete it at the end of each game. Have fun, y'all!")
+      localStorage.setItem('cookie_notice', 'true');
+    }
+  })
 </script>

--- a/app/views/rounds/show.html.erb
+++ b/app/views/rounds/show.html.erb
@@ -1,6 +1,6 @@
 <p>The results are in...</p>
 
-<h3><%= @round.question.text %></h3>
+<h3><%= @round.number %>. <%= @round.question.text %></h3>
 <h1><%= display_winner(@round) %></h1>
 
 <ol>

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -7,7 +7,7 @@
 
   <div class='field'>
     <%= form.label 'Which of your teammates best fits this question?' %>
-    <%= form.collection_select :nominee_id, @game.players, :id, :name, {}, class: 'form-control' %>
+    <%= form.collection_select :nominee_id, players_minus_nominator(@game, @player), :id, :name, {}, class: 'form-control' %>
   </div>
 
   <% if @player.nil? %>

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -1,4 +1,4 @@
-<h1>Cast Your Vote!</h1>
+<h1><%= @player.name %>, Cast Your Vote!</h1>
 
 <h2><%= @round.question.text %></h2>
 
@@ -10,10 +10,12 @@
     <%= form.collection_select :nominee_id, @game.players, :id, :name, {}, class: 'form-control' %>
   </div>
 
-  <div class='field'>
-    <%= form.label 'Please Select Your Name' %>
-    <%= form.collection_select :nominator_id, @game.players, :id, :name, {}, class: 'form-control' %>
-  </div>
+  <% if @player.nil? %>
+    <div class='field'>
+      <%= form.label 'Please Select Your Name' %>
+      <%= form.collection_select :nominator_id, @game.players, :id, :name, {}, class: 'form-control' %>
+    </div>
+  <% end %>
 
   <div class="mt-5 mb-5">
     <%= form.submit class: button_block %>

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -1,6 +1,6 @@
 <h1><%= @player.name %>, Cast Your Vote!</h1>
 
-<h2><%= @round.question.text %></h2>
+<h2><%= @round.number %>. <%= @round.question.text %></h2>
 
 <%= form_with(model: [@game, @round, @submission], local: true) do |form| %>
   <%= render 'shared/errors', object: @submission %>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -1,4 +1,4 @@
-<p>You submitted</p>
+<p><%= @submission.nominator.name %>, you submitted:</p>
 <h3><%= @submission.nominee.name %></h3>
 <p>for <%= @submission.round.question.text %></p>
 


### PR DESCRIPTION
## Related Issues & PRs
Closes #4

## Problems Solved
* Since we don't have sessions for non-admin users, players had to select their own name as a "nominator" every time they voted. Boooo. Lameo.
* Now we remember the user's player id in a cookie so they don't have to do that.
* Cookies are deleted at the end of each game.
* Cookies also expire in a day just in case.
* There is a fallback dropdown in case the user's browser blocks cookies. 

## Screenshots
Remembers and displays player name on submission pages:
<img width="493" alt="Screenshot 2020-06-17 18 16 50" src="https://user-images.githubusercontent.com/8680712/84961550-44a88a80-b0ca-11ea-8470-acba926d541e.png">

Remembers and excludes player from selection form. No longer includes dropdown for player to select themselves as a nominator:
<img width="500" alt="Screenshot 2020-06-17 18 27 56" src="https://user-images.githubusercontent.com/8680712/84961553-45412100-b0ca-11ea-9a93-f2930a711d2d.png">


## Things Learned
* `localStorage` is a convenient place to stash a cookie notice trigger. Just a wee touch of javascript will do the trick. 
* The `cookies` hash is a great place to store a temporary `player_id`. It's accessible in views and controllers and made my life so easy today. You can also set an expiration date on a cookie when you set the cookie so. This made me feel better about being sure to clean up after myself. 
